### PR TITLE
action_ prefix is missed

### DIFF
--- a/general/controllers.html
+++ b/general/controllers.html
@@ -69,7 +69,7 @@ class Controller_Example extends Controller\Base {
 		<h3>Special controller methods</h3>
 
 		<article>
-			<h4>index()</h4>
+			<h4>action_index()</h4>
 			<p>This method will be called if the controller is called without a second parameter. In the above example <kbd>www.yoursite.com/example/index</kbd> will be the same as <kbd>www.yoursite.com/example</kbd>.</p>
 		</article>
 


### PR DESCRIPTION
Just making a note, that action_ is a required prefix for normal controller methods, not the reserved ones (like before, after, router).
Maybe description should be slightly edided too? but since I'm not good in english, I'lll leave it for you guys :) 
