### PR TITLE
wrong example in validation

### DIFF
--- a/classes/validation.html
+++ b/classes/validation.html
@@ -362,8 +362,8 @@ class Myvalidation {
     {
         list($table, $field) = explode('.', $options);
 
-        $result = DB::select('LOWER ("$field")')
-            ->where("$field", '=', Str::lower($val))
+        $result = DB::select("LOWER (\"$field\")")
+            ->where($field, '=', Str::lower($val))
             ->from($table)->execute();
 
         return ! ($result->count() > 0);


### PR DESCRIPTION
DB::select('LOWER ("$field")') - is wrong. tried: DB::select("LOWER ($field)") - does not work  too, the only working scenario I have found is: DB::select("LOWER (\"$field\")")
