### PR TITLE
Link in Models to DB class returning 404 & Model documentation link

### DIFF
--- a/general/models.html
+++ b/general/models.html
@@ -55,7 +55,7 @@
 		
 		<pre class="php"><code>DB::select('title, content')->from('articles')->execute()->get();</code></pre>
 
-		<p>See more about native SQL queries and using the Query Builder in the <a href="../classes/database /db.html">DB class</a> documentation.</p>
+		<p>See more about native SQL queries and using the Query Builder in the <a href="../classes/database/db.html">DB class</a> documentation.</p>
 
 		<h3>Don't like SQL at all?</h3>
 

--- a/general/models.html
+++ b/general/models.html
@@ -55,7 +55,7 @@
 		
 		<pre class="php"><code>DB::select('title, content')->from('articles')->execute()->get();</code></pre>
 
-		<p>See more about native SQL queries and using the Query Builder in the <a href="../classes/db.html">DB class</a> documentation.</p>
+		<p>See more about native SQL queries and using the Query Builder in the <a href="../classes/database /db.html">DB class</a> documentation.</p>
 
 		<h3>Don't like SQL at all?</h3>
 

--- a/general/models.html
+++ b/general/models.html
@@ -35,7 +35,7 @@
 		</p>
 
 		<p>
-			See <a href="/packages/orm/creating_models.html">more about creating models</a> in the Orm Package documentation.
+			See <a href="../packages/orm/creating_models.html">more about creating models</a> in the Orm Package documentation.
 		</p>
 
 		<h3>How are Models used?</h3>

--- a/general/models.html
+++ b/general/models.html
@@ -34,6 +34,10 @@
 			call upon the Model to execute the queries. This way if your database changes you won't need to change all your Controllers but just the Model that acts upon it.
 		</p>
 
+		<p>
+			See <a href="/packages/orm/creating_models.html">more about creating models</a> in the Orm Package documentation.
+		</p>
+
 		<h3>How are Models used?</h3>
 
 		<p>


### PR DESCRIPTION
I know I edited one of them a month or two ago, but the other one needed fixing too. Didn’t spot it the first time.

Added an extra link for those reading through the model docs confused to where to turn to create their first model.
