### PR TITLE
Updated example on fieldset page.

### DIFF
--- a/classes/fieldset.html
+++ b/classes/fieldset.html
@@ -369,7 +369,8 @@
 					<th>Parameters</th>
 					<td>
 						<table class="parameters">
-							<tbody><tr>
+							<tbody>
+							<tr>
 								<th>Param</th>
 								<th>Default</th>
 								<th class="description">Description</th>
@@ -384,7 +385,8 @@
 								<td><i><code>null</code></i></td>
 								<td>If specified, sets the item to set from the passed Configuration array.</td>
 							</tr>
-						</tbody></table>
+							</tbody>
+						</table>
 					</td>
 				</tr>
 				<tr>
@@ -397,7 +399,7 @@
 						<i><code>//General example</code></i>
 						<code>$article_form->set_config($config);</code>
 						<br />
-						<i><code>//Example of setting attributes to form tag with Fieldset class</i></code>
+						<i><code>//Example of setting attributes to form tag with Fieldset class</code></i>
 						<code>$article_form->set_config('form_attributes', array('id' => 'my_form_id'));</code>
 					</td>
 				</tr>

--- a/classes/fieldset.html
+++ b/classes/fieldset.html
@@ -392,9 +392,13 @@
 					<td>Fuel\Core\Fieldset Object</td>
 				</tr>
 				<tr>
-					<th>Example</th>
+					<th>Examples</th>
 					<td>
+						<i><code>//General example</code></i>
 						<code>$article_form->set_config($config);</code>
+						<br />
+						<i><code>//Example of setting attributes to form tag with Fieldset class</i></code>
+						<code>$article_form->set_config('form_attributes', array('id' => 'my_form_id'));</code>
 					</td>
 				</tr>
 				</tbody>


### PR DESCRIPTION
Added example for adding form tag attributes with set_config.  Had to dig through Form class to figure out.  On another note, please read this forum thread about documentation consistency, it seems to me different people are documenting in slightly different ways.  Documentation SHOULD be standardized, right?

http://fuelphp.com/forums/topics/view/2499
