### PR TITLE
Textmate Project File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 nbproject
+*.tmproj


### PR DESCRIPTION
Added .gitignore item for textmate project files. Core & the main repo both have this but docs does not.
