### PR TITLE
Clearer Orm Model creation

### DIFF
--- a/packages/orm/creating_models.html
+++ b/packages/orm/creating_models.html
@@ -35,8 +35,7 @@
 		<section>
 			<h2 id="creation">Creating Models</h2>
 
-			<p>Creating a model takes little time, the convention is to use the <kbd>Model_</kbd> prefix and thus place
-				them in <kbd>app/classes/model/</kbd> but you are free to use whatever name you choose.</p>
+			<p>Creating a model takes little time, the convention is to use the <kbd>Model_</kbd> prefix for the class (eg Model_Article using the filename article.php) and thus place them in <kbd>app/classes/model/</kbd> but you are free to use whatever name you choose.</p>
 
 			<pre class="php"><code>class Model_Article extends Orm\Model {}</code></pre>
 

--- a/packages/orm/creating_models.html
+++ b/packages/orm/creating_models.html
@@ -35,7 +35,10 @@
 		<section>
 			<h2 id="creation">Creating Models</h2>
 
-			<p>Creating a model takes little time, the convention is to use the <kbd>Model_</kbd> prefix for the class (eg Model_Article using the filename article.php) and thus place them in <kbd>app/classes/model/</kbd> but you are free to use whatever name you choose.</p>
+			<p>Creating a model takes little time, the convention is to use the <kbd>Model_</kbd> 
+				prefix for the class (eg Model_Article using the filename article.php) and thus 
+				place them in <kbd>app/classes/model/</kbd> but you are free to use 
+				whatever name you choose.</p>
 
 			<pre class="php"><code>class Model_Article extends Orm\Model {}</code></pre>
 


### PR DESCRIPTION
At the moment the docs for creating a model reads `Creating a model takes little time, the convention is to use the Model_ prefix and thus place them in app/classes/model/ but you are free to use whatever name you choose.` which I read as calling the filename Model_ too.

I’ve changed it to read `Creating a model takes little time, the convention is to use the Model_ prefix for the class (eg Model_Article using the filename article.php) and thus place them in app/classes/model/ but you are free to use whatever name you choose.`
