### PR TITLE
Observer_Typing Parameter Correction

### DIFF
--- a/packages/orm/observers/included.html
+++ b/packages/orm/observers/included.html
@@ -252,7 +252,7 @@ protected static $_observers = array('Orm\\Observer_Typing' => array('before_sav
 							</td>
 						</tr>
 						<tr>
-							<th>is_nullable</th>
+							<th>null</th>
 							<td>bool</td>
 							<td>
 								Whether <kbd>null</kbd> is allowed as a value


### PR DESCRIPTION
The parameter for specifying whether NULL values are allowed was "is_nullable" but in the class's code "null" was being used
