### PR TITLE
Added correct value for Fuel::DEVELOPMENT

### DIFF
--- a/classes/fuel.html
+++ b/classes/fuel.html
@@ -53,7 +53,7 @@
 				<tr>
 					<th>DEVELOPMENT</th>
 					<td>string</td>
-					<td><pre class="php"><code>'dev'</code></pre></td>
+					<td><pre class="php"><code>'development'</code></pre></td>
 					<td>
 						Identifies the DEVELOPMENT environment.
 					</td>


### PR DESCRIPTION
The docs have Fuel::DEVELOPMENT as being equal to "dev" but it is in fact "development"
