### PR TITLE
Fixed example and return of $fieldset->show_errors()

### DIFF
--- a/classes/fieldset.html
+++ b/classes/fieldset.html
@@ -700,12 +700,12 @@ $article_form->set_config('key', 'value');</code></pre>
 				</tr>
 				<tr>
 					<th>Returns</th>
-					<td>Array of input or string value of specified field, or <kbd>false</kbd> if the field isn't found</td>
+					<td>String HTML markup</td>
 				</tr>
 				<tr>
 					<th>Example</th>
 					<td>
-						<pre class="php"><code>$validated_values = $article_form->validated();</code></pre>
+						<pre class="php"><code>echo $article_form->show_errors();</code></pre>
 					</td>
 				</tr>
 				</tbody>


### PR DESCRIPTION
Replaced wrong Example & Return for show_errors() in Fieldset class
