### PR TITLE
Added method docs for some of the Validation class methods

### DIFF
--- a/classes/validation/methods.html
+++ b/classes/validation/methods.html
@@ -30,9 +30,232 @@
 			The Validation class helps you validate user input, if you want to create a form &amp; its validation at
 			the same time use the <a href="../fieldset.html">Fieldset</a> class instead.
 		</p>
-		
+
 		<h2 id="methods">Class Methods</h2>
-		<p>Coming soon.</p>
+
+		<article>
+			<h4 id="method_forge">forge($fieldset = 'default')</h4>
+
+			<p>
+				The <strong>forge</strong> method returns a new Validation instance,
+				and links it with a Fieldset with name $fieldset.
+			</p>
+
+			<table class="method">
+				<tbody>
+					<tr>
+						<th class="legend">Static</th>
+						<td>Yes</td>
+					</tr>
+					<tr>
+						<th>Parameters</th>
+						<td>
+							<table class="parameters">
+								<tr>
+									<th>Param</th>
+									<th>Type</th>
+									<th>Default</th>
+									<th class="description">Description</th>
+								</tr>
+								<tr>
+									<th><kbd>$fieldset</kbd></th>
+									<td><em>string | Fieldset</em></td>
+									<td><pre class="php"><code>'default'</code></pre></td>
+									<td>The name or instance of the Fieldset to link to.</td>
+								</tr>
+						</table>
+						</td>
+					</tr>
+					<tr>
+						<th>Returns</th>
+						<td>\Validation Object</td>
+					</tr>
+					<tr>
+						<th>Throws</th>
+						<td>\DomainException, when the Fieldset name or instance already has a related Validation instance.</td>
+					</tr>
+					<tr>
+						<th>Example</th>
+						<td>
+							<pre class="php"><code>// Create a new validation instance
+$val = Validation::forge();
+
+// Associate the new Validation instance with a Fieldset, using the fieldset name
+$val = Validation::forge('my_fieldset');
+
+// Associate the new Validation instance with a Fieldset, by passing the fieldset instance
+$fieldset = Fieldset::instance('my_fieldset');
+$val = Validation::forge($fieldset);
+</code></pre>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</article>
+
+		<article>
+			<h4 id="method_instance">instance($name = null)</h4>
+
+			<p>
+				The <strong>instance</strong> method returns the Validation instance
+				related with the Fieldset instance with the identifier $name,
+				or the default Fieldset (is created if necessary).
+			</p>
+
+			<table class="method">
+				<tbody>
+					<tr>
+						<th class="legend">Static</th>
+						<td>Yes</td>
+					</tr>
+					<tr>
+						<th>Parameters</th>
+						<td>
+							<table class="parameters">
+								<tr>
+									<th>Param</th>
+									<th>Type</th>
+									<th>Default</th>
+									<th class="description">Description</th>
+								</tr>
+								<tr>
+									<th><kbd>$name</kbd></th>
+									<td><em>string</em></td>
+									<td><pre class="php"><code>null</code></pre></td>
+									<td>The name of the Fieldset whose Validation instance you want to return.</td>
+								</tr>
+						</table>
+						</td>
+					</tr>
+					<tr>
+						<th>Returns</th>
+						<td>
+							\Validation Object<br />
+							or <strong>false</strong> if the specified Fieldset instance doesn't exist
+						</td>
+					</tr>
+					<tr>
+						<th>Example</th>
+						<td>
+							<pre class="php"><code>// Get the Validation instance of the default Fieldset
+$val = Validation::instance();
+
+// Get the Validation instance of a particular Fieldset
+$val = Validation::instance('my_fieldset');
+</code></pre>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</article>
+
+		<article>
+			<h4 id="method_active">active()</h4>
+
+			<p>
+				The <strong>active</strong> method returns the currently active validation instance.
+			</p>
+
+			<table class="method">
+				<tbody>
+					<tr>
+						<th class="legend">Static</th>
+						<td>Yes</td>
+					</tr>
+					<tr>
+						<th>Parameters</th>
+						<td>
+							None
+						</td>
+					</tr>
+					<tr>
+						<th>Returns</th>
+						<td>Validation - currently active validation instance</td>
+					</tr>
+					<tr>
+						<th>Example</th>
+						<td>
+							<pre class="php"><code>// Get the currently active validation instance
+$val = Validation::active();
+</code></pre>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</article>
+
+		<article>
+			<h4 id="method_active_field">active_field()</h4>
+
+			<p>
+				The <strong>active_field</strong> method returns the field currently being validated.
+			</p>
+
+			<table class="method">
+				<tbody>
+					<tr>
+						<th class="legend">Static</th>
+						<td>Yes</td>
+					</tr>
+					<tr>
+						<th>Parameters</th>
+						<td>
+							None
+						</td>
+					</tr>
+					<tr>
+						<th>Returns</th>
+						<td>Fieldset_Field - the field currently being validated</td>
+					</tr>
+					<tr>
+						<th>Example</th>
+						<td>
+							<pre class="php"><code>// Get the field currently being validated
+$field = Validation::active_field();
+</code></pre>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</article>
+
+		<article>
+			<h4 id="method_fieldset">fieldset()</h4>
+
+			<p>
+				The <strong>fieldset</strong> method returns the related Fieldset.
+			</p>
+
+			<table class="method">
+				<tbody>
+					<tr>
+						<th class="legend">Static</th>
+						<td>No</td>
+					</tr>
+					<tr>
+						<th>Parameters</th>
+						<td>
+							None
+						</td>
+					</tr>
+					<tr>
+						<th>Returns</th>
+						<td>Fieldset - the related Fieldset</td>
+					</tr>
+					<tr>
+						<th>Example</th>
+						<td>
+							<pre class="php"><code>// Get the related Fieldset
+$val = Validation::forge('my_fieldset');
+$fieldset = $val->fieldset();
+</code></pre>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</article>
+
+		<p>More coming soon...</p>
 
 	</section>
 

--- a/classes/validation/validation.html
+++ b/classes/validation/validation.html
@@ -455,6 +455,18 @@ $val->add_model('Model_User');</code></pre>
         <strong>Note: </strong>
         You need the '_validation_' prefix for a method to be used in validation.
         </p>
+
+		<p>
+			It can be useful to use <a href="methods.html#method_active">Validation::active()</a>
+			and <a href="methods.html#method_active_field">Validation::active_field()</a>
+			to get the currently active validation instance and field currently being validated, respectively.
+		</p>
+
+		<p>For example, in the above you could do:</p>
+		<pre class="php"><code>public function _validation_unique($val, $options)
+{
+	Validation::active()->set_message('unique', 'The field :label must be unique, but :value has already been used');
+...</code></pre>
         </article>
 
 	</section>


### PR DESCRIPTION
Method docs added for:
- forge()
- instance()
- active()
- active_field()
- fieldset()

and added a comment about active() and active_field() to the bottom of the Extending Validation class section on the Validation/Introduction page
