### PR TITLE
Corrected spelling of 'establish'

### DIFF
--- a/packages/orm/relations/intro.html
+++ b/packages/orm/relations/intro.html
@@ -28,7 +28,7 @@
 
 		<p>Orm is short for <a href="http://en.wikipedia.org/wiki/Object_relational_mapper" target="_blank">Object
 			Relational Mapper</a> which does 2 things: it maps your database table rows to objects and it allows you
-			to esteblish relations between those objects.<br />
+			to establish relations between those objects.<br />
 			It follows closely the <a href="http://en.wikipedia.org/wiki/Active_record_pattern" target="_blank">
 			Active Record Pattern</a>, but was also influenced by other systems.</p>
 


### PR DESCRIPTION
Last commit reverted the correction of 'establish'. Fixed.
