### PR TITLE
Update documents to follow latest Model structure to use Model as namespace

### DIFF
--- a/general/models.html
+++ b/general/models.html
@@ -56,7 +56,7 @@
 			<h3 id="using_models">How are Models used?</h3>
 	
 			<p>
-				In Fuel a Model is essentially just a <a href="classes.html" title="Class Documentation">Class</a> like any other. They do nothing more than a library, but the Model_ prefix
+				In Fuel a Model is essentially just a <a href="classes.html" title="Class Documentation">Class</a> like any other. They do nothing more than a library, but the Model_ prefix or Model namespace 
 				helps to differentiate it from other classes. To do something useful with a Model you will need to use other classes.
 			</p>
 	
@@ -89,10 +89,10 @@
 			<p>One possible way of creating models is by using the <a href="../packages/orm/intro.html">Orm Package</a>, which adds a lot of functionality out-of-the-box to your models. There's an example of its usage below.</p>
 	
 			<pre class="php"><code>// find all articles
-$entry = Model_Article::find('all');
+$entry = Model\Article::find('all');
 
 // find all articles from category 1 order descending by date
-$entry = Model_Article::find('last', array(
+$entry = Model\Article::find('last', array(
     'where' => array('category_id', 1),
     'order_by' => array('date', 'desc')
 ));</code></pre>

--- a/general/viewmodels.html
+++ b/general/viewmodels.html
@@ -97,7 +97,7 @@
 	{
 		$this->title = 'Testing this ViewModel thing';
 
-		$this->articles = Model_Articles::find('all');
+		$this->articles = \Model\Articles::find('all');
 	}
 }</code></pre>
 	

--- a/general/viewmodels.html
+++ b/general/viewmodels.html
@@ -97,7 +97,7 @@
 	{
 		$this->title = 'Testing this ViewModel thing';
 
-		$this->articles = \Model\Articles::find('all');
+		$this->articles = Model\Articles::find('all');
 	}
 }</code></pre>
 	

--- a/packages/orm/creating_models.html
+++ b/packages/orm/creating_models.html
@@ -53,18 +53,22 @@
 			<section>
 				<h2 id="creation">Creating Models</h2>
 
-				<p>Creating a model takes little time, the convention is to use the <kbd>Model_</kbd>
-					prefix for the class (eg Model_Article using the filename article.php) and thus
+				<p>Creating a model takes little time, the convention is to use the <kbd>Model</kbd> namespace 
+					for the class (eg Model\Article using the filename article.php) and thus
 					place them in <kbd>app/classes/model/</kbd> but you are free to use
 					whatever name you choose.</p>
 
-				<pre class="php"><code>class Model_Article extends Orm\Model {}</code></pre>
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model {}</code></pre>
 
 				<p class="note">The above only works with the MySQL and MySQLi drivers because it needs to fetch the model
 					properties from the database. It is however not very efficient and thus discouraged to use it this way
 					because you'll always need that one extra query per model just to fetch the columnnames.</p>
 
-				<pre class="php"><code>class Model_Article extends Orm\Model
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model
 {
 	protected static $_properties = array('id', 'title', 'contents', 'publish');
 }</code></pre>
@@ -79,11 +83,13 @@
 
 				<h3 id="table_name">protected static $_table_name</h3>
 
-				<p>When this isn't set the <kbd>Model_</kbd> prefix is removed from the classname and the classname is
-					pluralized. Thus "Model_Article" expects table "articles". If you don't follow this convention you can
+				<p>When <kbd>Model</kbd> namespace is removed from the classname and the classname is
+					pluralized. Thus "Model\Article" expects table "articles". If you don't follow this convention you can
 					change it by setting the <kbd>$table_name</kbd> property.</p>
 
-				<pre class="php"><code>class Model_Article extends Orm\Model
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model
 {
 	protected static $_table_name = 'myarticles';
 }</code></pre>
@@ -93,7 +99,9 @@
 				<p>By default this is set to <kbd>array('id')</kbd>, if you use another column name or multiple primary
 					keys you need to set this property.</p>
 
-				<pre class="php"><code>class Model_Article extends Orm\Model
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model
 {
 	protected static $_primary_key = array('aid');
 }</code></pre>
@@ -110,7 +118,9 @@
 				<p>There's already a simple example above of adding all model properties, they can also be configured by
 				using the columnname as the key and setting options like type, label & validation.</p>
 
-				<pre class="php"><code>class Model_Article extends Orm\Model
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model
 {
 	protected static $_properties = array(
 		'id' => array('data_type' => 'int'),
@@ -149,7 +159,9 @@
 				it to any other database name configured in <kbd>app/config/db.php</kbd>. Note however that relations don't
 				work across connections.</p>
 
-				<pre class="php"><code>class Model_Article extends Orm\Model
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model
 {
 	protected static $_connection = 'articles_database';
 }</code></pre>

--- a/packages/orm/crud.html
+++ b/packages/orm/crud.html
@@ -60,12 +60,12 @@
 					<h2>Create</h2>
 
 					<pre class="php"><code>// option 1
-$new = new Model_Example();
+$new = new Model\Example();
 $new->property = 'something';
 $new->save();
 
 // option 2, use factory instead of new
-$new = Model_Example::forge();</code></pre>
+$new = Model\Example::forge();</code></pre>
 
 					<p class="note">After <kbd>save()</kbd> the model has been saved to the database and if you're using an
 						<kbd>auto_increment</kbd> primary key it will automatically be set on the instance after successful
@@ -76,11 +76,11 @@ $new = Model_Example::forge();</code></pre>
 					<pre class="php"><code>$props = array('property' => 'something');
 
 // using "new"
-$new = new Model_Example($props);
+$new = new Model\Example($props);
 $new->save();
 
 // option 2, use factory instead of new
-$new = Model_Example::forge($props)->save();</code></pre>
+$new = Model\Example::forge($props)->save();</code></pre>
 				</article>
 
 				<article id="read">
@@ -93,44 +93,44 @@ $new = Model_Example::forge($props)->save();</code></pre>
 					<h3>Find by ID</h3>
 
 					<pre class="php"><code>// you know there's an article with ID=2
-$entry = Model_Article::find(2);
+$entry = Model\Article::find(2);
 
 // ...or when using multiple primary keys
-$entry = Model_Article::find(array(2, 5));</code></pre>
+$entry = Model\Article::find(array(2, 5));</code></pre>
 
-					<p>In this example it will return either an instance of Model_Article or null when the ID wasn't found.</p>
+					<p>In this example it will return either an instance of Model\Article or null when the ID wasn't found.</p>
 
 					<h3 id="find_first_last">Find first/last</h3>
 
 					<pre class="php"><code>// find the first entry
-$entry = Model_Article::find('first');
+$entry = Model\Article::find('first');
 
 // find the last entry added when ordered by date
-$entry = Model_Article::find('last', array('order_by' => 'date'));</code></pre>
+$entry = Model\Article::find('last', array('order_by' => 'date'));</code></pre>
 
-					<p>In this example it will return either an instance of Model_Article or null when the ID wasn't found.</p>
+					<p>In this example it will return either an instance of Model\Article or null when the ID wasn't found.</p>
 
 					<h3 id="find_all">Find all</h3>
 
 					<pre class="php"><code>// find all articles
-$entry = Model_Article::find('all');
+$entry = Model\Article::find('all');
 
 // find all articles from category 1 order descending by date
-$entry = Model_Article::find('all', array(
+$entry = Model\Article::find('all', array(
 	'where' =&gt; array(
 		array('category_id', 1),
 	),
 	'order_by' =&gt; array('date' =&gt; 'desc'),
 ));</code></pre>
 
-					<p>In this example it will always return an array of instances of Model_Article.</p>
+					<p>In this example it will always return an array of instances of Model\Article.</p>
 
 					<h3 id="find_chaining">Find using method chaining</h3>
 
 					<p>When you use the <kbd>find()</kbd> method without properties it will return an Orm\Query object
 						which you can use, and possibly reuse to find entries.</p>
 
-					<pre class="php"><code>$query = Model_Article::find()->where('category_id', 1)->order_by('date', 'desc');
+					<pre class="php"><code>$query = Model\Article::find()->where('category_id', 1)->order_by('date', 'desc');
 
 // We want to know the total number of articles for pagination
 $number_of_articles = $query->count();
@@ -148,7 +148,7 @@ $all_articles = $query->limit(15)->get();</code></pre>
 				<article id="update">
 					<h2>Update</h2>
 
-					<pre class="php"><code>$entry = Model_Article::find(4);
+					<pre class="php"><code>$entry = Model\Article::find(4);
 $entry->title = 'My first edit';
 $entry->author = 'Total n00b';
 $entry->save();</code></pre>
@@ -159,7 +159,7 @@ $entry->save();</code></pre>
 				<article id="delete">
 					<h2>Delete</h2>
 
-					<pre class="php"><code>$entry = Model_Article::find(4);
+					<pre class="php"><code>$entry = Model\Article::find(4);
 $entry->delete();</code></pre>
 
 					<p>Again nothing more to it: Find and delete.</p>
@@ -185,13 +185,13 @@ $entry->delete();</code></pre>
 								<td>string <kbd>$column</kbd>, [string <kbd>$operator</kbd>,] mixed <kbd>$value</kbd></td>
 								<td>
 									<pre class="php"><code>// Single where
-Model_Article::find()-&gt;where('id', 4);
-Model_Article::find('all', array('where' =&gt; array('category_id' => 5)));
+Model\Article::find()-&gt;where('id', 4);
+Model\Article::find('all', array('where' =&gt; array('category_id' => 5)));
 
 // Multiple where usage examples
-Model_Article::find()-&gt;where('id', 4)->where('category_id', '>', 1);
-Model_Article::find()-&gt;where(array('id' => 4, 'category_id' => 6));
-Model_Article::find('all', array('where' => array(array('category_id', '=', 5), array('publish', '<', time()))));</code></pre>
+Model\Article::find()-&gt;where('id', 4)->where('category_id', '>', 1);
+Model\Article::find()-&gt;where(array('id' => 4, 'category_id' => 6));
+Model\Article::find('all', array('where' => array(array('category_id', '=', 5), array('publish', '<', time()))));</code></pre>
 								</td>
 							</tr>
 							<tr>

--- a/packages/orm/observers/included.html
+++ b/packages/orm/observers/included.html
@@ -128,12 +128,12 @@ protected static $_observers = array('Orm\\Observer_Validation' => array('before
 	{
 		$this->template->title = "Articles";
 		$this->template->content = View::forge('articles/index');
-		$this->template->content->articles = Model_Article::find('all');
+		$this->template->content->articles = Model\Article::find('all');
 	}
 
 	public function action_view($id = false)
 	{
-		if ( ! $article = Model_Article::find($id))
+		if ( ! $article = Model\Article::find($id))
 		{
 			throw new Request404Exception();
 		}
@@ -145,7 +145,7 @@ protected static $_observers = array('Orm\\Observer_Validation' => array('before
 
 	public function action_create()
 	{
-		$article = Model_Article::forge();
+		$article = Model\Article::forge();
 
 		if (Input::method() == 'POST')
 		{
@@ -172,7 +172,7 @@ protected static $_observers = array('Orm\\Observer_Validation' => array('before
 
 	public function action_edit($id = false)
 	{
-		if (!$article = Model_Article::find($id))
+		if (!$article = Model\Article::find($id))
 		{
 			throw new Request404Exception();
 		}
@@ -202,7 +202,7 @@ protected static $_observers = array('Orm\\Observer_Validation' => array('before
 
 	public function action_delete($id = null)
 	{
-		if ($article = Model_Article::find($id))
+		if ($article = Model\Article::find($id))
 		{
 			$article->delete();
 

--- a/packages/orm/observers/intro.html
+++ b/packages/orm/observers/intro.html
@@ -17,7 +17,7 @@
 			<div class="table">
 				<h1>
 					<strong>Fuel, a PHP 5.3 Framework</strong>
-					Documentation
+					Docnumentation
 				</h1>
 
 				<form id="google_search">
@@ -72,7 +72,9 @@
 					When the Observer is in the same namespace as the Model and prefixed with <kbd>Observer_</kbd> you can
 					leave out the "Observer_" prefix. In all other cases you have to provide the full classname.</p>
 	
-				<pre class="php"><code>class Model_Article
+				<pre class="php"><code>namespace Model;
+
+class Article extends \Orm\Model
 {
 	protected static $_observers = array(
 		'example', // will call Observer_Example class for all events

--- a/packages/orm/relations/belongs_to.html
+++ b/packages/orm/relations/belongs_to.html
@@ -58,38 +58,38 @@
 
 				<h3>Example</h3>
 
-				<p>Let's say we have a model <kbd>Model_Comment</kbd> and it <em>belongs to</em> a <kbd>Model_Post</kbd>
-					(which in turn <em>has many</em> comments) the ID of the Model_Post is saved with the Model_Comment
+				<p>Let's say we have a model <kbd>Model\Comment</kbd> and it <em>belongs to</em> a <kbd>Model\Post</kbd>
+					(which in turn <em>has many</em> comments) the ID of the Model\Post is saved with the Model\Comment
 					instance in its own table. This means the <kbd>comments</kbd> table will have a column
 					<kbd>post_id</kbd> (or something else you configure). If you keep to the defaults all you need to do
-					is add <kbd>'post'</kbd> to the <kbd>$_belongs_to</kbd> static property of the Model_Comment:</p>
+					is add <kbd>'post'</kbd> to the <kbd>$_belongs_to</kbd> static property of the Model\Comment:</p>
 
 				<pre class="php"><code>protected static $_belongs_to = array('post'));</code></pre>
 
 				<p>Below are examples for establishing and breaking belongs-to relations:</p>
 
 				<pre class="php"><code>// both main and related object are new:
-$comment = new Model_Comment();
-$comment->post = new Model_Post();
+$comment = new Model\Comment();
+$comment->post = new Model\Post();
 $comment->save();
 
 // both main and related object already exist
-$comment = Model_Comment::find(6);
-$comment->post = Model_Post::find(1);
+$comment = Model\Comment::find(6);
+$comment->post = Model\Post::find(1);
 $comment->save();
 
 // break the relationship established above
-$comment = Model_Comment::find(6);
+$comment = Model\Comment::find(6);
 $comment->post = null;
 $comment->save();</code></pre>
 
 				<h3>Full config example with defaults as values</h3>
 
-				<pre class="php"><code>// in a Model_Comment which belong to a post
+				<pre class="php"><code>// in a Model\Comment which belong to a post
 protected static $_belongs_to = array(
 	'post' => array(
 		'key_from' => 'comment_id',
-		'model_to' => 'Model_Post',
+		'model_to' => 'Model\\Post',
 		'key_to' => 'id',
 		'cascade_save' => true,
 		'cascade_delete' => false,

--- a/packages/orm/relations/has_many.html
+++ b/packages/orm/relations/has_many.html
@@ -59,39 +59,39 @@
 
 				<h3>Example</h3>
 
-				<p>Let's say we have a model <kbd>Model_Post</kbd> and it <em>has many</em> <kbd>Model_Comment</kbd>s
-					(which in turn <em>belong to</em> the post). The ID of the Model_Post is saved with the Model_Comment
+				<p>Let's say we have a model <kbd>Model\Post</kbd> and it <em>has many</em> <kbd>Model\Comment</kbd>s
+					(which in turn <em>belong to</em> the post). The ID of the Model\Post is saved with the Model\Comment
 					instance in its own table. This means the <kbd>comments</kbd> table will have a column
 					<kbd>post_id</kbd> (or something else you configure), while the posts table won't mention the comments.
 					If you keep to the defaults all you need to do is add <kbd>'comments'</kbd> to the
-					<kbd>$_has_many</kbd> static property of the Model_User:</p>
+					<kbd>$_has_many</kbd> static property of the Model\User:</p>
 
 				<pre class="php"><code>protected static $_has_many = array('comments');</code></pre>
 
 				<p>Below are examples for establishing and breaking has-many relations:</p>
 
 				<pre class="php"><code>// both main and related object are new:
-$post = new Model_Post();
-$post->comments[] = new Model_Comment();
+$post = new Model\Post();
+$post->comments[] = new Model\Comment();
 $post->save();
 
 // both main and related object already exist
-$post = Model_Post::find(1);
-$post->comments[6] = Model_Comment::find(6); // assigning it to comments[6] is not required but recommended
+$post = Model\Post::find(1);
+$post->comments[6] = Model\Comment::find(6); // assigning it to comments[6] is not required but recommended
 $post->save();
 
 // break the relationship established above
-$post = Model_Post::find(1);
+$post = Model\Post::find(1);
 unset($post->comments[6]);
 $post->save();</code></pre>
 
 				<h3>Full config example with defaults as values</h3>
 
-				<pre class="php"><code>// in a Model_Post which has many comments
+				<pre class="php"><code>// in a Model\Post which has many comments
 protected static $_has_many = array(
 	'comments' => array(
 		'key_from' => 'id',
-		'model_to' => 'Model_Comment',
+		'model_to' => 'Model\Comment',
 		'key_to' => 'post_id',
 		'cascade_save' => true,
 		'cascade_delete' => false,

--- a/packages/orm/relations/has_one.html
+++ b/packages/orm/relations/has_one.html
@@ -59,39 +59,39 @@
 
 				<h3>Example</h3>
 
-				<p>Let's say we have a model <kbd>Model_User</kbd> and it <em>has one</em> a <kbd>Model_Profile</kbd>
-					(which in turn <em>belongs to</em> the user). The ID of the Model_User is saved with the Model_Profile
+				<p>Let's say we have a model <kbd>Model\User</kbd> and it <em>has one</em> a <kbd>Model\Profile</kbd>
+					(which in turn <em>belongs to</em> the user). The ID of the Model\User is saved with the Model\Profile
 					instance in its own table. This means the <kbd>profiles</kbd> table will have a column
 					<kbd>user_id</kbd> (or something else you configure), while the user table won't mention the profile.
 					If you keep to the defaults all you need to do is add <kbd>'profile'</kbd> to the
-					<kbd>$_has_one</kbd> static property of the Model_User:</p>
+					<kbd>$_has_one</kbd> static property of the Model\User:</p>
 
 				<pre class="php"><code>protected static $_has_one = array('profile');</code></pre>
 
 				<p>Below are examples for establishing and breaking has-one relations:</p>
 
 				<pre class="php"><code>// both main and related object are new:
-$user = new Model_User();
-$user->profile = new Model_Profile();
+$user = new Model\User();
+$user->profile = new Model\Profile();
 $user->save();
 
 // both main and related object already exist
-$user = Model_User::find(6);
-$user->profile = Model_Profile::find(1);
+$user = Model\User::find(6);
+$user->profile = Model\Profile::find(1);
 $user->save();
 
 // break the relationship established above
-$user = Model_User::find(6);
+$user = Model\User::find(6);
 $user->profile = null;
 $user->save();</code></pre>
 
 				<h3>Full config example with defaults as values</h3>
 
-				<pre class="php"><code>// in a Model_User which has one profile
+				<pre class="php"><code>// in a Model\User which has one profile
 protected static $_has_one = array(
 	'profile' => array(
 		'key_from' => 'id',
-		'model_to' => 'Model_Profile',
+		'model_to' => 'Model\Profile',
 		'key_to' => 'user_id',
 		'cascade_save' => true,
 		'cascade_delete' => false,

--- a/packages/orm/relations/intro.html
+++ b/packages/orm/relations/intro.html
@@ -70,14 +70,14 @@
 
 				<pre class="php"><code>protected static $_has_many = array('comments');</code></pre>
 
-				<p>This example, if specified in <kbd>Model_Article</kbd>, enables fetching of an array of
-					<kbd>Model_Comment</kbd> objects which have the field <kbd>article_id</kbd> matching the primary key of
+				<p>This example, if specified in <kbd>Model\Article</kbd>, enables fetching of an array of
+					<kbd>Model\Comment</kbd> objects which have the field <kbd>article_id</kbd> matching the primary key of
 					a given Article instance through the property <kbd>comments</kbd>.</p>
 
 				<h3>Fully configured</h3>
 
 				<pre class="php"><code>protected static $_has_many = array('comments' => array(
-	'model_to' => 'Model_Fancy_Comment',
+	'model_to' => 'Model\Fancy_Comment',
 	'key_from' => 'article_id',
 	'key_to' => 'parent_article_id',
 	'cascade_save' => true,
@@ -88,7 +88,7 @@
 				<p>In the basic example, Orm automatically assumes the model name and field mapping. This example
 					explicitly specifies the class name of the target model, the fields used to relate them, and whether
 					actions performed on the current object should be cascaded to the target. It will return an array of
-					<kbd>Model_Fancy_Comment</kbd> object where the comment's <kbd>parent_article_id</kbd> field
+					<kbd>Model\Fancy_Comment</kbd> object where the comment's <kbd>parent_article_id</kbd> field
 					corresponds to the current object's <kbd>article_id</kbd>. When saving an object the operation is
 					also performed on its loaded relations, deleting isn't cascaded by default but can be if you switch
 					this on.</p>
@@ -114,9 +114,9 @@
 						<tr>
 							<th>model_to</th>
 							<td>Calculated from alias</td>
-							<td>If specified, must the the full class name of the target model (ex. <kbd>Model_Comment</kbd>).<br />
-								By default, this value is formed by prepending 'Model_' to the singular form of the alias
-								(ex. 'comments' becomes 'Model_Comment'), it is also expected to be in the same namespace as
+							<td>If specified, must the the full class name of the target model (ex. <kbd>Model\Comment</kbd>).<br />
+								By default, this value is formed by prepending 'Model\' to the singular form of the alias
+								(ex. 'comments' becomes 'Model\Comment'), it is also expected to be in the same namespace as
 								the current model.</td>
 						</tr>
 						<tr>
@@ -127,7 +127,7 @@
 						<tr>
 							<th>key_to</th>
 							<td>Calculated from the current model name</td>
-							<td>By default, a relationship from a <kbd>Model_Article</kbd> to many <kbd>Model_Comment</kbd>s
+							<td>By default, a relationship from a <kbd>Model\Article</kbd> to many <kbd>Model\Comment</kbd>s
 								would use the field <kbd>article_id</kbd> in the comments table</td>
 						</tr>
 						<tr>
@@ -164,14 +164,14 @@
 					you request them.</p>
 
 				<pre class="php"><code>// eager loading, using joins:
-$post = Model_Post::find('all', array('related' => array('comments')));
+$post = Model\Post::find('all', array('related' => array('comments')));
 // or
-$post = Model_Post::find()->related('comments')->get();
+$post = Model\Post::find()->related('comments')->get();
 // $post->comments is available without any further querying after this
 
 // or use lazy loading, it won't use joins but query a relation once requested
 // first get a "post", 1 query without join
-$post = Model_Post::find('first');
+$post = Model\Post::find('first');
 // now request the comments (not yet loaded), which will do another query without join automatically
 $comments = $post->comments;</code></pre>
 
@@ -183,7 +183,7 @@ $comments = $post->comments;</code></pre>
 					conditions (see config table below) will be used of course.</p>
 
 				<pre class="php"><code>// using array querying
-$post = Model_Post::find('first', array(
+$post = Model\Post::find('first', array(
 	'related' => array(
 		'articles' => array(
 			'order_by' => array('id' => 'desc'),
@@ -196,7 +196,7 @@ $post = Model_Post::find('first', array(
 ));
 
 // using method chaining
-$post = Model_Post::query()->related('articles', array(
+$post = Model\Post::query()->related('articles', array(
 	'order_by' => array('id' => 'desc'),
 	'where' => array(
 		array('publish_date', '>', time()),
@@ -205,7 +205,7 @@ $post = Model_Post::query()->related('articles', array(
 )->get_one();
 
 // but the same can also be done by prefixing the relation name to the column:
-$post = Model_Post::query()->related('articles')
+$post = Model\Post::query()->related('articles')
 	->order_by('articles.id', 'desc')
 	->where('articles.publish_date', '>', time())
 	->where('articles.published', 1)
@@ -221,7 +221,7 @@ $post = Model_Post::query()->related('articles')
 					load the "parent" relation before it's relation. Otherwise an exception will be thrown.</p>
 
 				<pre class="php"><code>// using array querying
-$post = Model_Post::find('first', array(
+$post = Model\Post::find('first', array(
 	'related' => array(
 		'articles' => array(
 			'related' => array(
@@ -238,7 +238,7 @@ $post = Model_Post::find('first', array(
 ));
 
 // using only method chaining
-$post = Model_Post::query()
+$post = Model\Post::query()
 	->related('articles')
 	->related('articles.user')
 	->related('articles.user.profile')
@@ -247,7 +247,7 @@ $post = Model_Post::query()
 	->get_one();
 
 // or combine array & method chaining
-$post = Model_Post::query()
+$post = Model\Post::query()
 	->related('articles', array(
 		'related' => array('user' => array(
 			'where' => array('active' => 1),

--- a/packages/orm/relations/many_many.html
+++ b/packages/orm/relations/many_many.html
@@ -80,18 +80,18 @@
 							<th>table_through</th>
 							<td>Calculated from model_to and model_from alphabetically ordered</td>
 							<td>This is the table that connects the 2 models and has both their IDs in it. For 2 models
-								like Model_User and Model_Post it will be named posts_users by default (both plural).</td>
+								like Model\User and Model\Post it will be named posts_users by default (both plural).</td>
 						</tr>
 						<tr>
 							<th>key_through_from</th>
 							<td>Calculated from the current model name</td>
-							<td>The key that matches the current model's primary key. If your current model is Model_Post
+							<td>The key that matches the current model's primary key. If your current model is Model\Post
 								this will be post_id by default</td>
 						</tr>
 						<tr>
 							<th>key_through_to</th>
 							<td>Calculated from the related model name</td>
-							<td>The key that matches the related model's primary key. If your related model is Model_User
+							<td>The key that matches the related model's primary key. If your related model is Model\User
 								this will be user_id by default</td>
 						</tr>
 					</tbody>
@@ -99,12 +99,12 @@
 
 				<h3>Example</h3>
 
-				<p>Let's say we have a model <kbd>Model_Post</kbd> and it <em>has many and belongs to many</em>
-					<kbd>Model_User</kbd>s. The ID of the Model_Post is along with the ID of the Model_User in a table
+				<p>Let's say we have a model <kbd>Model\Post</kbd> and it <em>has many and belongs to many</em>
+					<kbd>Model\User</kbd>s. The ID of the Model\Post is along with the ID of the Model\User in a table
 					called <kbd>posts_users</kbd> (default order is alphabetical). That table has just 2 columns:
 					<kbd>post_id</kbd> and <kbd>user_id</kbd> which are together the primary key of that table.<br />
 					If you keep to the defaults all you need to do is add <kbd>'users'</kbd> to the
-					<kbd>$_many_many</kbd> static property of the Model_Post:</p>
+					<kbd>$_many_many</kbd> static property of the Model\Post:</p>
 
 				<pre class="php"><code>protected static $_many_many = array('users'));</code></pre>
 
@@ -119,23 +119,23 @@
 				<p>Below are examples for establishing and breaking has-many relations:</p>
 
 				<pre class="php"><code>// both main and related object are new:
-$post = new Model_Post();
-$post->users[] = new Model_User();
+$post = new Model\Post();
+$post->users[] = new Model\User();
 $post->save();
 
 // both main and related object already exist
-$user = Model_User::find(8);
-$user->posts[1] = Model_Post::find(1);
+$user = Model\User::find(8);
+$user->posts[1] = Model\Post::find(1);
 $user->save();
 
 // break the relationship established above
-$post = Model_Post::find(1);
+$post = Model\Post::find(1);
 unset($post->users[8]);
 $post->save();</code></pre>
 
 				<h3>Full config example with defaults as values</h3>
 
-				<pre class="php"><code>// in a Model_Post which has and belongs to many Users
+				<pre class="php"><code>// in a Model\Post which has and belongs to many Users
 // = multiple posts per user and multiple users (authors) per post
 protected static $_many_many = array(
 	'users' => array(
@@ -143,7 +143,7 @@ protected static $_many_many = array(
 		'key_through_from' => 'post_id', // column 1 from the table in between, should match a posts.id
 		'table_through' => 'posts_users', // both models plural without prefix in alphabetical order
 		'key_through_to' => 'user_id', // column 2 from the table in between, should match a users.id
-		'model_to' => 'Model_User',
+		'model_to' => 'Model\User',
 		'key_to' => 'id',
 		'cascade_save' => true,
 		'cascade_delete' => false,


### PR DESCRIPTION
As used in Model_Crud, Orm\Model documents should follow the same structure (use Model as namespace instead of Model_ prefix)
