### PR TITLE
The where method in Mongo_Db has to be passed as array.

### DIFF
--- a/classes/mongo/methods.html
+++ b/classes/mongo/methods.html
@@ -1369,7 +1369,7 @@ $insert_id = $mongodb->insert('users', array(
 $mongodb = \Mongo_Db::instance();
 
 // Update a user
-$bool = $mongodb->where('id', $an_id)->update('users', array(
+$bool = $mongodb->where(array('id' => $an_id))->update('users', array(
 	'name' => 'John',
 	'surname' => 'Doe',
 	'email' => 'john@doe.com',


### PR DESCRIPTION
In the example, the where was passed like where('foo' => 'bar') but has to be passed as array, like where(array('foo' => 'bar')).
