### PR TITLE
Add class="plain" to the <pre> tag to fix issue with string causing page 

### DIFF
--- a/installation/troubleshooting.html
+++ b/installation/troubleshooting.html
@@ -111,7 +111,7 @@ RewriteRule ^(.*)$ /index.php/$1 [L]
 	
 				<h3 id="oil_db_error">Oil cannot connect to DB but application can</h3>
 	
-				<pre>mysql_connect(): [2002] No such file or directory (trying to connect via unix:///var/mysql/mysql.sock) in /Users/phil/Sites/fuel/fuel/core/classes/database/mysql/connection.php on 73</pre>
+				<pre class="plain"><code>mysql_connect(): [2002] No such file or directory (trying to connect via unix:///var/mysql/mysql.sock) in /Users/phil/Sites/fuel/fuel/core/classes/database/mysql/connection.php on 73</code></pre>
 	
 				<h4>Happens When...</h4>
 	


### PR DESCRIPTION
Add class="plain" to the <pre> tag to fix issue with string causing page to scroll sideways. 
