### PR TITLE
Updated combined.js so that a back-to-top button is added in the footer

### DIFF
--- a/assets/js/combined.js
+++ b/assets/js/combined.js
@@ -689,4 +689,14 @@ $("document").ready(function(){
 		$(this).find('.column').last().addClass('last');
 	});
 	setup();
+	
+	var to_top = $('<a>', {
+		href : '#back_to_top',
+		html : 'Back To Top',
+		click : function(){$(window).scrollTo(0, 400);},
+		css : {'float':'right', 'margin-right':20}
+	});
+	
+	$('footer p').css('float', 'left').after(to_top); 
+	
 });


### PR DESCRIPTION
Updated combined.js so that a back-to-top button is added in the footer. Helps in going back to TOC easily when reading long pages. Please implement this or a variation of this if you are not accepting a fixed header as its a pain to scroll back every time you want to switch to a different section of the docs
