### PR TITLE
Only Model_Crud oil code generation use Model namespace, Orm\Model always

### DIFF
--- a/packages/oil/generate.html
+++ b/packages/oil/generate.html
@@ -163,11 +163,7 @@ class Create_posts
 
 				<pre class="php"><code>&lt;php
 
-namespace Model;
-
-use \Orm\Model;
-
-class Post extends Orm\Model { 
+class Model_Post extends \Orm\Model { 
 	
 	protected static $_observers = array(
 		'Orm\Observer_CreatedAt' => array('before_insert'),
@@ -209,11 +205,7 @@ class Create_posts
 				<pre class="cli"><code>$ php oil g model post title:varchar[50] body:text user_id:int --orm --no-timestamp</code></pre>
 				<pre class="php"><code>&lt;php
 
-namespace Model;
-
-use \Orm\Model;
-
-class Post extends Orm\Model { 
+class Model_Post extends \Orm\Model { 
 
 }
 


### PR DESCRIPTION
Only Model_Crud oil code generation use Model namespace, Orm\Model always use Model_ prefix
