### PR TITLE
Update View documentation to replace deprecated auto_encode() with auto_...

### DIFF
--- a/classes/view.html
+++ b/classes/view.html
@@ -56,7 +56,7 @@
 			</p>
 
 			<article>
-				<h4 class="method" id="method_construct">__construct($file = null, $data = null, $auto_encode = null)</h4>
+				<h4 class="method" id="method_construct">__construct($file = null, $data = null, $filter = null)</h4>
 				<table class="method">
 					<tbody>
 						<tr>
@@ -74,17 +74,17 @@
 									</tr>
 									<tr>
 										<th><kbd>$file</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">the view filename, if not supplied you must supply it later through <em>set_filename</em> or supply it in <em>render</em>. View files should be relative to the <em>app/views</em> directory.</td>
 									</tr>
 									<tr>
 										<th><kbd>$data</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">array of values</td>
 									</tr>
 									<tr>
-										<th><kbd>$auto_encode</kbd></th>
-										<td><em>null</em></td>
+										<th><kbd>$filter</kbd></th>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">set to <em>true</em> or <em>false</em> to set auto encoding, defaults to main config setting (app/config/config.php)</td>
 									</tr>
 								</table>
@@ -98,10 +98,10 @@
 							<th>Example</th>
 							<td>
 								<pre class="php"><code>$view = new View('path/to/view', array(
-		'menu' => $menu,
-		'articles' => $articles,
-		'footer_links' => $footer_links,
-	));</code></pre>
+	'menu' => $menu,
+	'articles' => $articles,
+	'footer_links' => $footer_links,
+));</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -109,7 +109,7 @@
 			</article>
 
 			<article>
-				<h4 class="method" id="method_forge">forge($file = null, $data = null, $auto_encode = null)</h4>
+				<h4 class="method" id="method_forge">forge($file = null, $data = null, $filter = null)</h4>
 				<p>The <strong>forge</strong> method returns a new View object.</p>
 				<table class="method">
 					<tbody>
@@ -128,17 +128,17 @@
 									</tr>
 									<tr>
 										<th><kbd>$file</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">the view filename, if not supplied you must supply it later through <em>set_filename</em> or supply it in <em>render</em>. View files should be relative to the <em>app/views</em> directory and be supplied without the <strong>.php</strong> file extension.</td>
 									</tr>
 									<tr>
 										<th><kbd>$data</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">array of values</td>
 									</tr>
 									<tr>
-										<th><kbd>$auto_encode</kbd></th>
-										<td><em>null</em></td>
+										<th><kbd>$filter</kbd></th>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">tet to <em>true</em> or <em>false</em> to set auto encoding, defaults to main config setting (app/config/config.php)</td>
 									</tr>
 								</table>
@@ -152,11 +152,11 @@
 							<th>Example</th>
 							<td>
 								<pre class="php"><code>// Will create a View object for APPPATH/
-	$view = View::forge('path/to/view', array(
-		'menu' => $menu,
-		'articles' => $articles,
-		'footer_links' => $footer_links,
-	));</code></pre>
+$view = View::forge('path/to/view', array(
+	'menu' => $menu,
+	'articles' => $articles,
+	'footer_links' => $footer_links,
+));</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -164,8 +164,8 @@
 			</article>
 
 			<article>
-				<h4 class="method" id="method_auto_encode">auto_encode($encode = true)</h4>
-				<p>The <strong>auto_encode</strong> sets whether to encode the data or not on a View instance.</p>
+				<h4 class="method" id="method_auto_encode">auto_filter($filter = true)</h4>
+				<p>The <strong>auto_filter</strong> sets whether to encode the data or not on a View instance.</p>
 				<table class="method">
 					<tbody>
 						<tr>
@@ -182,8 +182,8 @@
 										<th class="description">Description</th>
 									</tr>
 									<tr>
-										<th><kbd>$encode</kbd></th>
-										<td><em>true</em></td>
+										<th><kbd>$filter</kbd></th>
+										<td><pre class="php"><code>true</code></pre></td>
 										<td class="description">whether to encode the data or not on a View instance</td>
 									</tr>
 								</table>
@@ -197,24 +197,24 @@
 							<th>Example</th>
 							<td>
 								<pre class="php"><code>$view = View::forge('path/to/view', array(
-		'menu' => $menu,
-		'articles' => $articles,
-		'footer_links' => $footer_links,
-	));
+	'menu' => $menu,
+	'articles' => $articles,
+	'footer_links' => $footer_links,
+));
 
-	$view->auto_encode();
+$view->auto_filter();
 
-	// or set it to false
+// or set it to false
 
-	$view->auto_encode(false);
+$view->auto_filter(false);
 
-	// or chain it
+// or chain it
 
-	$view = View::forge('path/to/view', array(
-		'menu' => $menu,
-		'articles' => $articles,
-		'footer_links' => $footer_links,
-	))->auto_encode();</code></pre>
+$view = View::forge('path/to/view', array(
+	'menu' => $menu,
+	'articles' => $articles,
+	'footer_links' => $footer_links,
+))->auto_filter();</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -256,7 +256,7 @@
 							<td>
 								<pre class="php"><code>$view = new View();
 
-	$view->set_filename('path/to/view');</code></pre>
+$view->set_filename('path/to/view');</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -264,7 +264,7 @@
 			</article>
 
 			<article>
-				<h4 class="method" id="method_set">set($key, $value = null, $encode = null)</h4>
+				<h4 class="method" id="method_set">set($key, $value = null, $filter = null)</h4>
 				<p>The <strong>set</strong> assigns a variable to a view.</p>
 				<table class="method">
 					<tbody>
@@ -288,12 +288,12 @@
 									</tr>
 									<tr>
 										<th><kbd>$value</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">the value</td>
 									</tr>
 									<tr>
-										<th><kbd>$encode</kbd></th>
-										<td><em>null</em></td>
+										<th><kbd>$filter</kbd></th>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">set to <em>true</em> or <em>false</em> to encoding, defaults to main auto encoding setting</td>
 									</tr>
 								</table>
@@ -307,18 +307,18 @@
 							<th>Example</th>
 							<td>
 								<pre class="php"><code>$view = new View;
-	$view->set('users', $users, false);
+$view->set('users', $users, false);
 
-	// or set an array
+// or set an array
 
-	$view->set(array(
-		'users' => $users,
-		'articles' => $articles,
-	), null, true);
+$view->set(array(
+	'users' => $users,
+	'articles' => $articles,
+), null, true);
 
-	// If you need HTML / Javascript passed you need to set the last param to false
-	// when output encoding is enabled.
-	$view->set('example', '&lt;h1&gt;Heading&lt;/h1&gt;', false);</code></pre>
+// If you need HTML / Javascript passed you need to set the last param to false
+// when output encoding is enabled.
+$view->set('example', '&lt;h1&gt;Heading&lt;/h1&gt;', false);</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -326,7 +326,60 @@
 			</article>
 
 			<article>
-				<h4 class="method" id="method_set_global">set_global($key, $value = null, $encode = null)</h4>
+				<h4 class="method" id="method_set_safe">set_safe($key, $value = null)</h4>
+				<p>The same as <code>set()</code>, except this defaults to not-encoding the variable on output.</p>
+				<table class="method">
+					<tbody>
+						<tr>
+							<th>Static</th>
+							<td>No</td>
+						</tr>
+						<tr>
+							<th>Parameters</th>
+							<td>
+								<table class="parameters">
+									<tr>
+										<th>Param</th>
+										<th>Default</th>
+										<th class="description">Description</th>
+									</tr>
+									<tr>
+										<th><kbd>$key</kbd></th>
+										<td><em>required</em></td>
+										<td class="description">variable name or array of variables</td>
+									</tr>
+									<tr>
+										<th><kbd>$value</kbd></th>
+										<td><pre class="php"><code>null</code></pre></td>
+										<td class="description">the value</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<th>Returns</th>
+							<td>Current View object</td>
+						</tr>
+						<tr>
+							<th>Example</th>
+							<td>
+								<pre class="php"><code>$view = new View;
+$view->set_safe('users', $users);
+
+// or set an array
+
+$view->set_safe(array(
+	'users' => $users,
+	'articles' => $articles,
+), null);</code></pre>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</article>
+
+			<article>
+				<h4 class="method" id="method_set_global">set_global($key, $value = null, $filter = null)</h4>
 				<p>The <strong>set_global</strong> sets a variable accessible for all views.</p>
 				<table class="method">
 					<tbody>
@@ -350,12 +403,12 @@
 									</tr>
 									<tr>
 										<th><kbd>$value</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">the value</td>
 									</tr>
 									<tr>
-										<th><kbd>$encode</kbd></th>
-										<td><em>null</em></td>
+										<th><kbd>$filter</kbd></th>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">set to <em>true</em> or <em>false</em> to encoding, defaults to main auto encoding setting</td>
 									</tr>
 								</table>
@@ -370,12 +423,12 @@
 							<td>
 								<pre class="php"><code>View::set_global('users', $users, false);
 
-	// or set an array
+// or set an array
 
-	View::set_global(array(
-		'users' => $users,
-		'articles' => $articles,
-	), null, true);</code></pre>
+View::set_global(array(
+	'users' => $users,
+	'articles' => $articles,
+), null, true);</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -412,7 +465,7 @@
 									</tr>
 									<tr>
 										<th><kbd>$value</kbd></th>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">the value</td>
 									</tr>
 								</table>
@@ -426,14 +479,14 @@
 							<th>Example</th>
 							<td>
 								<pre class="php"><code>$view = new View;
-	$view->bind('users', $users, false);
+$view->bind('users', $users, false);
 
-	// or set an array
+// or set an array
 
-	$view->bind(array(
-		'users' => $users,
-		'articles' => $articles,
-	), null, true);</code></pre>
+$view->bind(array(
+	'users' => $users,
+	'articles' => $articles,
+), null, true);</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -511,7 +564,7 @@
 									<tr>
 										<th><kbd>$file</kbd></th>
 										<td><em>string</em></td>
-										<td><em>null</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
 										<td class="description">the view filename without the extension</td>
 									</tr>
 								</table>
@@ -526,13 +579,13 @@
 							<td>
 								<pre class="php"><code>$html = View::forge()->render('path/to/view');
 
-	// or
+// or
 
-	$html = View::forge('path/to/view')->render();
+$html = View::forge('path/to/view')->render();
 
-	// or
+// or
 
-	$html = View::forge()->set_filename('path/to/view')->render();</code></pre>
+$html = View::forge()->set_filename('path/to/view')->render();</code></pre>
 							</td>
 						</tr>
 					</tbody>
@@ -542,7 +595,7 @@
 			<h3 id="procedural_helpers">Procedural helpers</h3>
 
 			<article>
-				<h4 id="function_render" class="method" data-class="">render($view, $data = array())</h4>
+				<h4 id="function_render" class="method" data-class="">render($view, $data = array(), $auto_filter = null)</h4>
 				<p>The <strong>render</strong> function is an alias for <a href="#method_render">View::render</a>.</p>
 				<table class="method">
 					<tbody>
@@ -567,6 +620,12 @@
 										<td><em>array</em></td>
 										<td><pre class="php"><code>array()</code></pre></td>
 										<td class="description">an array of data to be passed to the view</td>
+									</tr>
+									<tr>
+										<th><kbd>$auto_filter</kbd></th>
+										<td><em>bool</em></td>
+										<td><pre class="php"><code>null</code></pre></td>
+										<td class="description">whether to filter the data or not</td>
 									</tr>
 								</table>
 							</td>


### PR DESCRIPTION
Update View documentation to replace deprecated auto_encode() with auto_filter(), update all available variable, add set_safe() doc and edit whitespace/html attribute usage

Signed-off-by: crynobone crynobone@gmail.com
