### PR TITLE
Added note to Lang class about the Config::set method

### DIFF
--- a/classes/lang.html
+++ b/classes/lang.html
@@ -50,7 +50,7 @@
 			
 			<p>
 				The default language, which is <code>en</code>, is set in <kbd>app/config/config.php</kbd>. 
-				Use the <a href="/classes/config.html#/method_set">Config set method</a> to change the value.
+				Use the <a href="./classes/config.html#/method_set">Config set method</a> to change the value.
 			</p>
 			<pre class="php"><code>Config::set('language', 'cy');</code></pre>
 

--- a/classes/lang.html
+++ b/classes/lang.html
@@ -50,7 +50,7 @@
 			
 			<p>
 				The default language, which is <code>en</code>, is set in <kbd>app/config/config.php</kbd>. 
-				Use the <a href="./config.html#/method_set">Config set method</a> to change the value.
+				Use the <a href="./config.html#method_set">Config set method</a> to change the value.
 			</p>
 			<pre class="php"><code>Config::set('language', 'cy');</code></pre>
 

--- a/classes/lang.html
+++ b/classes/lang.html
@@ -49,7 +49,8 @@
 			<p>The Lang class allows you to set language variables using language files in your application.</p>
 			
 			<p>
-				The default language, which is <code>en</code>, is set in <kbd>app/config/config.php</kbd>. Use the <a href="/classes/config.html#/method_set">Config set method</a> to change the value.
+				The default language, which is <code>en</code>, is set in <kbd>app/config/config.php</kbd>. 
+				Use the <a href="/classes/config.html#/method_set">Config set method</a> to change the value.
 			</p>
 			<pre class="php"><code>Config::set('language', 'cy');</code></pre>
 

--- a/classes/lang.html
+++ b/classes/lang.html
@@ -47,6 +47,11 @@
 			<h2>Lang Class</h2>
 
 			<p>The Lang class allows you to set language variables using language files in your application.</p>
+			
+			<p>
+				The default language, which is <code>en</code>, is set in <kbd>app/config/config.php</kbd>. Use the <a href="/classes/config.html#/method_set">Config set method</a> to change the value.
+			</p>
+			<pre class="php"><code>Config::set('language', 'cy');</code></pre>
 
 			<article>
 				<h4 class="method" id="method_load">load($file, $group = null, $language = null)</h4>

--- a/classes/lang.html
+++ b/classes/lang.html
@@ -50,7 +50,7 @@
 			
 			<p>
 				The default language, which is <code>en</code>, is set in <kbd>app/config/config.php</kbd>. 
-				Use the <a href="./classes/config.html#/method_set">Config set method</a> to change the value.
+				Use the <a href="./config.html#/method_set">Config set method</a> to change the value.
 			</p>
 			<pre class="php"><code>Config::set('language', 'cy');</code></pre>
 


### PR DESCRIPTION
It’s not obvious straight away that one uses the Config class to control the language. Also added a note about the existence of the default language.
