### PR TITLE
Update installation/instructions.html

### DIFF
--- a/installation/instructions.html
+++ b/installation/instructions.html
@@ -100,6 +100,7 @@
 	Made writable: APPPATH/cache
 	Made writable: APPPATH/logs
 	Made writable: APPPATH/tmp
+	Made writable: APPPATH/config
 </code>
 </pre>
 				</li>


### PR DESCRIPTION
The command "php oil refine install" makes "config" dir writable.
Made writable: APPPATH/cache
Made writable: APPPATH/logs
Made writable: APPPATH/tmp
Made writable: APPPATH/config  // This line is missing.

Code is changed, as shown in https://github.com/fuel/core/commit/406fd14a6faac3df49bf076f2e5fd5224d86f994#tasks/install.php
Document remains unchanged.
