### PR TITLE
Docs update to match fuel core Cookie::get() method.

### DIFF
--- a/classes/cookie.html
+++ b/classes/cookie.html
@@ -95,8 +95,8 @@
 			<p>If one or more of these values are missing from the global configuration, the class will use the defaults as defined in this table.</p>
 
 			<article>
-				<h4 class="method" id="method_get">get($name, $default = null)</h4>
-				<p>The <strong>get</strong> method allows you to read a $_COOKIE variable.</p>
+				<h4 class="method" id="method_get">get($name = null, $default = null)</h4>
+				<p>The <strong>get</strong> method allows you to read a $_COOKIE variable. If <strong>null</strong>, all cookies are returned.</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -114,7 +114,7 @@
 								</tr>
 								<tr>
 									<th><kbd>$name</kbd></th>
-									<td><i>Required</i></td>
+									<td><i>Optional</i></td>
 									<td>The key in the $_COOKIE array.</td>
 								</tr>
 								<tr>

--- a/classes/cookie.html
+++ b/classes/cookie.html
@@ -96,7 +96,7 @@
 
 			<article>
 				<h4 class="method" id="method_get">get($name = null, $default = null)</h4>
-				<p>The <strong>get</strong> method allows you to read a $_COOKIE variable. If <strong>null</strong>, all cookies are returned.</p>
+				<p>The <strong>get</strong> method allows you to read a $_COOKIE variable. If no name given, all cookies are returned.</p>
 				<table class="method">
 					<tbody>
 					<tr>

--- a/classes/lang.html
+++ b/classes/lang.html
@@ -171,7 +171,7 @@ Lang:load('foo::example', 'bar', 'it');</code></pre>
 						<th>Example</th>
 						<td>
 							<pre class="php"><code>// Outputs Hello world
-$this->output = Lang::get('hello', array('name' => 'world');
+$this->output = Lang::get('hello', array('name' => 'world'));
 
 // Outputs Plop
 $this->output = Lang::get('test.something');</code></pre>


### PR DESCRIPTION
Updated docs to match this pull request:

https://github.com/fuel/core/pull/860
