### PR TITLE
Corrected download link for fuelphp 1.2

### DIFF
--- a/installation/download.html
+++ b/installation/download.html
@@ -51,7 +51,7 @@
 			<ul>
 				<li id="releases">Releases
 					<ul>
-						<li><a href="https://github.com/downloads/fuel/fuel/fuelphp-v1.2.zip">Download 1.2</a></li>
+						<li><a href="https://github.com/downloads/fuel/fuel/fuelphp-1.2.zip">Download 1.2</a></li>
 						<li><a href="https://github.com/downloads/fuel/fuel/fuelphp-v1.1.zip">Download 1.1</a></li>
 						<li><a href="https://github.com/downloads/fuel/fuel/fuel-1.0.1.zip">Download 1.0.1</a></li>
 						<li><a href="https://github.com/downloads/fuel/fuel/fuel-1.0.zip">Download 1.0</a></li>


### PR DESCRIPTION
The download link to the _fuelphp 1.2_ package was corrected; previously it leaded to 404 page on github.
