### PR TITLE
Clarify array return type from AUTH::get_user_id()

### DIFF
--- a/packages/auth/simpleauth/login.html
+++ b/packages/auth/simpleauth/login.html
@@ -475,7 +475,7 @@
 						</tr>
 						<tr>
 							<th>Returns</th>
-							<td>mixed. returns an array in the form <strong>array(driver_id, user_id)</strong> if a user is logged in, or <strong>false</strong> otherwise.</td>
+							<td>mixed. returns a numeric array in the form <strong>array([0]=>driver_id, [1]=>user_id)</strong> if a user is logged in, or <strong>false</strong> otherwise.</td>
 						</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
For backwards compatbility, WanWizard noted that an associative return type array would break existing implementations.

Instead, clarify documentation to explicitly indicate a numeric array is returned and in which order.
