### PR TITLE
Modify a misprint about orm\model::to_array()

### DIFF
--- a/packages/orm/creating_models.html
+++ b/packages/orm/creating_models.html
@@ -196,7 +196,7 @@
 				</p>
 				<pre class="php"><code>class Model_User extends Orm\Model
 {
-	protected static $_to_array_filter = array(
+	protected static $_to_array_exclude = array(
 		'password', 'login_hash', 'salt'	// exclude these columns from being exported
 	);
 }</code></pre>


### PR DESCRIPTION
Modify a misprint about orm\model::to_array(), from $_to_array_filter to $_to_array_exclude in an example code.
