### PR TITLE
Changed text to blob type of profile_fields in simpleauth

### DIFF
--- a/packages/auth/simpleauth/intro.html
+++ b/packages/auth/simpleauth/intro.html
@@ -185,7 +185,7 @@
   `email` varchar(255) NOT NULL,
   `last_login` varchar(25) NOT NULL,
   `login_hash` varchar(255) NOT NULL,
-  `profile_fields` text NOT NULL,
+  `profile_fields` blob NOT NULL,
   `created_at` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`,`email`)


### PR DESCRIPTION
According to [php docs](http://php.net/manual/en/function.serialize.php#refsect1-function.serialize-returnvalues) changed field type to avoid data losing.

Data losing reported by [Maxlab](https://github.com/Maxlab)
