### PR TITLE
Added ref (next, prev) attributes to the pagination links documentation

### DIFF
--- a/classes/pagination.html
+++ b/classes/pagination.html
@@ -206,7 +206,7 @@ $this->render('welcome/index', $data);</code></pre>
 						<tr>
 							<th>previous-link</th>
 							<td>string</td>
-							<td><pre class="html"><code>\t\t&lt;a href="{uri}"&gt;{page}&lt;/a&gt;\n</code></pre></td>
+							<td><pre class="html"><code>\t\t&lt;a href="{uri}" rel="prev"&gt;{page}&lt;/a&gt;\n</code></pre></td>
 							<td>
 								Markup that will be used to generate the previous page link.
 							</td>
@@ -222,7 +222,7 @@ $this->render('welcome/index', $data);</code></pre>
 						<tr>
 							<th>previous-inactive-link</th>
 							<td>string</td>
-							<td><pre class="html"><code>\t\t&lt;a href="{uri}"&gt;{page}&lt;/a&gt;\n</code></pre></td>
+							<td><pre class="html"><code>\t\t&lt;a href="{uri}" rel="prev"&gt;{page}&lt;/a&gt;\n</code></pre></td>
 							<td>
 								Markup that will be used to generate the previous page markup for inactive links.
 							</td>
@@ -270,7 +270,7 @@ $this->render('welcome/index', $data);</code></pre>
 						<tr>
 							<th>next-link</th>
 							<td>string</td>
-							<td><pre class="html"><code>\t\t&lt;a href="{uri}"&gt;{page}&lt;/a&gt;\n</code></pre></td>
+							<td><pre class="html"><code>\t\t&lt;a href="{uri}" rel="next"&gt;{page}&lt;/a&gt;\n</code></pre></td>
 							<td>
 								Markup that will be used to generate the next page link.
 							</td>
@@ -286,7 +286,7 @@ $this->render('welcome/index', $data);</code></pre>
 						<tr>
 							<th>next-inactive-link</th>
 							<td>string</td>
-							<td><pre class="html"><code>\t\t&lt;a href="{uri}"&gt;{page}&lt;/a&gt;\n</code></pre></td>
+							<td><pre class="html"><code>\t\t&lt;a href="{uri}" rel="next"&gt;{page}&lt;/a&gt;\n</code></pre></td>
 							<td>
 								Markup that will be used to generate the next page link for inactive links.
 							</td>


### PR DESCRIPTION
Signed-off-by: Pablo de la Concepción Sanz pconcepcion@gmail.com

Added the rel="prev" and rel="next" attributes to the pagination documentation to reflect the changes done in the pagination code templates in the configuration (core/config/pagination.ph)
