### PR TITLE
Upload class: DOCROOT contains DS

### DIFF
--- a/classes/upload/usage.html
+++ b/classes/upload/usage.html
@@ -313,7 +313,7 @@
 			<h3 id="usage_example">Usage example</h3>
 			<pre class="php"><code>// Custom configuration for this upload
 $config = array(
-	'path' => DOCROOT.DS.'files',
+	'path' => DOCROOT.'files',
 	'randomize' => true,
 	'ext_whitelist' => array('img', 'jpg', 'jpeg', 'gif', 'png'),
 );


### PR DESCRIPTION
In a Upload class example, the DOCROOT has a DS appended to it, but this is included in `public/index.php` line 11.
