### PR TITLE
fixed typo classes/date.html

### DIFF
--- a/classes/date.html
+++ b/classes/date.html
@@ -181,7 +181,7 @@ Fuel\Core\Date Object
 						<th>Example</th>
 						<td>
 							<pre class="php"><code>// set the display timezone to 'America/Lima'
-Date::display_timezone('America/Lima'));</code></pre>
+Date::display_timezone('America/Lima');</code></pre>
 						</td>
 					</tr>
 					</tbody>
@@ -429,7 +429,7 @@ echo Date::time_ago(strtotime("12 April 1964"), strtotime("01 March 2012"), 'yea
 			<article>
 				<h4 class="method" id="method_format">format($pattern_key = 'local', $timezone = null)</h4>
 				<p>
-					The <strong>formatted</strong> method returns a formatted date as specified by the pattern key. The
+					The <strong>format</strong> method returns a formatted date as specified by the pattern key. The
 					patterns are defined in the <kbd>fuel/core/config/date.php</kbd> config file - you can add your own
 					by creating a similar file in <kbd>app/config</kbd>.
 				</p>


### PR DESCRIPTION
duplicate ')' at line: 184.
typo method name at line: 432.
