### PR TITLE
Fixed example for Asset::get_file, as described in issue #513

### DIFF
--- a/classes/asset/usage.html
+++ b/classes/asset/usage.html
@@ -444,7 +444,7 @@ echo Asset::js('jquery.js');</code></pre>
 							<th>Example</th>
 							<td>
 								<pre class="php"><code>// returns something like 'http://example.org/assets/js/jquery.js'
-echo Asset::get_file('jquery.js');</code></pre>
+echo Asset::get_file('jquery.js', 'js');</code></pre>
 							</td>
 						</tr>
 						</tbody>


### PR DESCRIPTION
Made the change as suggested by WanWizard in:
https://github.com/fuel/docs/issues/513#issuecomment-13709348
