### PR TITLE
Add support for HEAD method in cURL driver

### DIFF
--- a/classes/request/curl.html
+++ b/classes/request/curl.html
@@ -83,7 +83,7 @@ $curl = Request::forge('http://rest.example.org/api/v1/this/info', 'curl');
 								<tr>
 									<th><kbd>$method</kbd></th>
 									<td><i>required</i></td>
-									<td>The HTTP method (GET, POST, PUT, DELETE) to use for this request.</td>
+									<td>The HTTP method (GET, HEAD, POST, PUT, DELETE) to use for this request.</td>
 								</tr>
 							</table>
 						</td>


### PR DESCRIPTION
Adding HEAD parameter in the set_method function.

Documentation related to [fuel/core/#1423 pull request](https://github.com/fuel/core/pull/1423).
