### PR TITLE
1.8/develop

### DIFF
--- a/classes/file/usage.html
+++ b/classes/file/usage.html
@@ -592,7 +592,7 @@ File::rename(APPPATH.'tmp/file.jpg', DOCROOT.'folder/image.jpg', 'tmp', 'public'
 			</article>
 
 			<article>
-				<h4 class="method" id="method_copy">copy($path, $new_path, $area = null, $source_area = null, $target_area = null)</h4>
+				<h4 class="method" id="method_copy">copy($path, $new_path, $source_area = null, $target_area = null)</h4>
 				<p>Copies a file.</p>
 				<table class="method">
 					<tbody>

--- a/classes/file/usage.html
+++ b/classes/file/usage.html
@@ -509,7 +509,6 @@ $contents = File::read_dir(DOCROOT, 0, array(
 						<th>Throws</th>
 						<td>
 							<kbd>OutsideAreaException</kbd> when a path not inside the file area.
-							<kbd>FileAccessException</kbd> when the filetype is not allowed.
 						</td>
 					</tr>
 					<tr>
@@ -580,7 +579,6 @@ File::rename(APPPATH.'tmp/file.jpg', DOCROOT.'folder/image.jpg', 'tmp', 'public'
 						<th>Throws</th>
 						<td>
 							<kbd>OutsideAreaException</kbd> when a path not inside the file area.
-							<kbd>FileAccessException</kbd> when the filetype is not allowed.
 						</td>
 					</tr>
 					<tr>
@@ -644,7 +642,6 @@ File::rename(APPPATH.'tmp/file.jpg', DOCROOT.'folder/image.jpg', 'tmp', 'public'
 						<th>Throws</th>
 						<td>
 							<kbd>OutsideAreaException</kbd> when a path not inside the file area.
-							<kbd>FileAccessException</kbd> when the filetype is not allowed.
 							<kbd>InvalidPathException</kbd> when the source path is not a file.
 							<kbd>FileAccessException</kbd> when the destination file already exists.
 						</td>


### PR DESCRIPTION
- "copy" method definition has not $area argument.
- In some methods, FileAccessException description is wrong. threre is no "filetype".
