### PR TITLE
Removing broken links from tutorials.html

### DIFF
--- a/installation/tutorials.html
+++ b/installation/tutorials.html
@@ -60,8 +60,6 @@
 						<li><a href="http://www.novius-labs.com/fuelphp,c,5.html">FuelPHP tutorial series</a> (Novius Labs, in French)</li>
 						<li><a href="http://www.phpbuilder.com/columns/FuelPHP_Gilmore_08-25-2011.php3">Getting Started with the Fuel PHP Framework</a> (Jason Gilmore)</li>
 						<li><a href="http://www.phpbuilder.com/columns/MySQL_Fuel/mysql-fuel-php-app.php3">Creating a Database-driven Fuel PHP Application</a> (Jason Gilmore)</li>
-						<li><a href="http://www.marcopace.it/blog/2012/11/fuelphp-separation-between-back-end-and-front-end">FuelPHP: Separation between Back-End and Front-End</a> (Marco Pace)</li>
-						<li><a href="http://www.marcopace.it/blog/2012/12/fuelphp-i18n-internationalization-of-a-web-application">FuelPHP: i18n, internationalization of a web application</a> (Marco Pace)</li>
 					</ul>
 				</li>
 				<li id="screencasts">Screencasts


### PR DESCRIPTION
FuelPHP: Separation between Back-End and Front-End (Marco Pace)
FuelPHP: i18n, internationalization of a web application (Marco Pace)

Links are broken and showing 404 page
