### PR TITLE
Nested transactions - rollback_all

### DIFF
--- a/classes/database/db.html
+++ b/classes/database/db.html
@@ -1192,7 +1192,7 @@ DB::count_last_query();
 			</article>
 
 			<article>
-				<h4 class="method" id="method_rollback_transaction">rollback_transaction($db = null)</h4>
+				<h4 class="method" id="method_rollback_transaction">rollback_transaction($db = null, $rollback_all = true)</h4>
 				<p>The <strong>rollback_transaction</strong> method rolls back all pending transactional queries.</p>
 				<table class="method">
 					<tbody>
@@ -1213,6 +1213,11 @@ DB::count_last_query();
 										<th><kbd>$db</kbd></th>
 										<td><strong>null</strong></td>
 										<td class="description">The database connection.</td>
+									</tr>
+									<tr>
+										<th><kbd>$rollback_all</kbd></th>
+										<td><strong>true</strong></td>
+										<td class="description">The rollback mode:<br>true - rollback everything and close transaction;<br>false - rollback only current level.</td>
 									</tr>
 								</table>
 							</td>


### PR DESCRIPTION
Document fix for nested transactions. Added the rollback_all parameter into DB::rollback_transaction()
