### PR TITLE
Make note of the $nocolor property in the stderr/stdout docs

### DIFF
--- a/classes/cli.html
+++ b/classes/cli.html
@@ -398,7 +398,11 @@ Cli::wait(5, true);</code></pre>
 
 			<article>
 				<h4 class="method" id="method_stdout">stdout($resource = null)</h4>
-				<p>Changes or retrieves the current stdout stream. This is STDOUT by default.</p>
+				<p>Changes or retrieves the current stdout stream. This is STDOUT by default.<br/>
+                    <br/>
+                    Note the public property <code>$nocolor</code> can be set to true to force all output
+                    to plaintext.
+                </p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -450,7 +454,11 @@ file_put_contents('out.log', stream_get_contents($buffer));
 
 			<article>
 				<h4 class="method" id="method_stderr">stderr($resource = null)</h4>
-				<p>Changes or retrieves the current stderr stream. This is STDERR by default.</p>
+				<p>Changes or retrieves the current stderr stream. This is STDERR by default.<br/>
+                    <br/>
+                    Note the public property <code>$nocolor</code> can be set to true to force all output
+                    to plaintext.
+                </p>
 				<table class="method">
 					<tbody>
 					<tr>


### PR DESCRIPTION
Wasn't sure how to document public static properties otherwise... is there a preferred way?
