### PR TITLE
Updated param descriptions and added example Mongo over UNIX Sockets

### DIFF
--- a/classes/mongo/introduction.html
+++ b/classes/mongo/introduction.html
@@ -76,7 +76,7 @@
 						<th>hostname</th>
 						<td>string</td>
 						<td>yes</td>
-						<td>the hostname</td>
+						<td>the TCP hostname, OR a UNIX socket filepath</td>
 					</tr>
 					<tr>
 						<th>database</th>
@@ -88,7 +88,7 @@
 						<th>port</th>
 						<td>number</td>
 						<td>no</td>
-						<td>the port to use in the connection</td>
+						<td>the port to use in the connection, OR <em>0</em> if the <strong>hostname</strong> is a UNIX socket</td>
 					</tr>
 					<tr>
 						<th>replicaset</th>
@@ -122,6 +122,7 @@
 				'database'   => 'mongo_fuel',
 			),
 
+
 			// List your own groups below.
 			'my_mongo_connection' => array(
 				'hostname'   => 'localhost',
@@ -130,6 +131,14 @@
 				'username'   => 'user',
 				'password'   => 'p@s$w0rD',
 			),
+
+			// An alternative group example using a UNIX socket connection, instead of the TCP localhost
+			'my_mongo_sock' => array(
+				'hostname'   => '/tmp/mongodb-27017.sock',
+				'port'   => 0,
+				'database'   => 'mongo_fuel',
+			),
+
 		),
 	</code></pre>
 


### PR DESCRIPTION
This is optional, but also very easy for someone to enable via their config/db.php.

UNIX sockets tend to be faster than TCP/IP, so letting folks know about this option is encouraged.  I'm using it in a stage environment and it has been seamless after changing just the hostname and port, as mentioned in the proposed pull request.

Direct UNIX socket connections from the PHP PECL Mongo driver have been around since version 2010-08-06 in [version 1.0.9 ](http://pecl.php.net/package-info.php?package=mongo&version=1.0.9).

PHP has documentation for socket-based connections.
http://php.net/manual/en/mongo.connecting.uds.php

Also, Mongo has defaulted to running a UNIX socket since at least version 2.2
http://docs.mongodb.org/v2.2/reference/configuration-options/#nounixsocket
