### PR TITLE
Simplified path to $document_root and fixed "try_files" for Nginx Installation

### DIFF
--- a/installation/instructions.html
+++ b/installation/instructions.html
@@ -239,7 +239,7 @@ $ php composer.phar update
 
 	location / {
 		index index.php;
-		try_files $uri $uri/ /deep/sub/folder/index.php$is_args$args;
+		try_files $uri $uri/ /index.php$is_args$args;
 	}
 
 	location ~ \.php$ {
@@ -247,7 +247,7 @@ $ php composer.phar update
 		fastcgi_pass 127.0.0.1:9000;
 		fastcgi_index index.php;
 		fastcgi_param FUEL_ENV "production";
-		fastcgi_param SCRIPT_FILENAME /var/www/fuelphp/public$fastcgi_script_name;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 	}
 }
 </code></pre>


### PR DESCRIPTION
Simplified path to $document_root which is always the same. Fixed "try_files" because URL rewriting will not work
