### PR TITLE
adding some notes for installation using zip file

### DIFF
--- a/installation/instructions.html
+++ b/installation/instructions.html
@@ -137,6 +137,10 @@ $ ./composer.phar update --prefer-source
 </code>
 </pre>
 
+<p class="note">
+	The zip file is created for people that don't want to use git or want to use FuelPHP locally, The zip file does not contains any repositories, so you're not supposed to have composer update the fuel files. It is meant to run FuelPHP without any additional dependencies. If you want a complete installation managed by composer, don't install the zip. Please clone the fuel repository and let composer do the rest. If you are using zip file, it will still allow you to run composer for additional components, and will not give an error.
+</p>
+
 			<h2 id="composer">Composer</h2>
 
 			<p>


### PR DESCRIPTION
I have add some notes for installing fuelphp using zip file and using composer for update composer, it is not complete instruction for "how to use composer after installing zip file", just saying that use zip file if you will not use composer,
