### PR TITLE
Syntax error in set_flash() method example

### DIFF
--- a/classes/session/usage.html
+++ b/classes/session/usage.html
@@ -344,7 +344,7 @@ Session::delete('array.varC');
 Session::set_flash('step', 2);
 
 // you can also store more complex values
-Session::set_flash('array', array('varA', 'varB', 'varC' => array('val1', 'val2'));
+Session::set_flash('array', array('varA', 'varB', 'varC' => array('val1', 'val2')));
 </code></pre>
 						</td>
 					</tr>


### PR DESCRIPTION
One parenthesis left in second set_flash() method example.
