### PR TITLE
Upgrade - add other files that may need manual fix

### DIFF
--- a/installation/upgrade.html
+++ b/installation/upgrade.html
@@ -130,10 +130,14 @@ $ rm -rf fuel/packages/orm/ fuel/packages/parser/ fuel/vendor/
 
 			<h4 id="app_others">Other included files</h4>
 			<p>
-				Other files that might need upgrading are the 'Oil' bootstrap script and the .htaccess file, and the files needed
-				by PHPUnit. If you haven't changed them, just replace them by the new version, to make sure you don't run into
-				issues when using them.
-			</p>
+                Other files may need upgrading. If you haven't changed them, just replace them with the new version, to make sure 
+                you don't run into issues.</p>
+
+                <p><code>oil</code> - the 'Oil' bootstrap script, <code>.htaccess</code> and files needed by PHPUnit.</p>
+                <p> <code>app/config/config.php</code> - you may see an <em>"There is no security.output_filter defined"</em> error.<br/>
+                Keep your current config file, but copy over the "security" array from the latest version.</p>
+                <p> <code>app/bootstrap.php</code> - if you still have "Load in the Autoloader" (lines 3-6) these should be removed.<br/>
+                This is the cause of the <em>"Cannot declare class Fuel\Core\Autoloader, because the name is already in use"</em> error.</p>
 
 			<h3 id="tips">Using upstream repositories</h3>
 


### PR DESCRIPTION
Tidy the 'Other included files' section, and mention:

app/config/config.php (how to fix security warning)
app/bootstrap.php (needed for upgrades from 1.6 or earlier)

(re-requested on 1.9/develop as per PR #735 - sorry for the delay)
