### PR TITLE
Fix quick installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 			<p>If you value your time and want to get things up and running in seconds instead of minutes, you can use our quick installer instead. Using the <a href="http://en.wikipedia.org/wiki/CURL">curl</a> library, you can install a very basic version of oil. From there you can create new full applications of Fuel.</p>
 
 			<pre class="cli"><code># quick install oil from the web
-$ curl get.fuelphp.com/oil | sh
+$ curl https://get.fuelphp.com/oil | sh
 # now that oil is installed, create a blog project in a directory called Sites
 $ cd Sites/
 $ oil create blog</code></pre>


### PR DESCRIPTION
`get.fuelphp.com/oil` does not work now, because it redirects to `https://...`.
