### PR TITLE
Fix HTML tag typo on running migration section

### DIFF
--- a/packages/oil/generate.html
+++ b/packages/oil/generate.html
@@ -546,7 +546,7 @@ $ php oil refine migrate:up
 
 				<p class="note">The following field types are supported: <strong>string[n]</strong>, <strong>varchar[n]</strong>, <strong>int[n]</strong>, <strong>enum[value1, value2]</strong>, <strong>decimal[n, n]</strong>, <strong>float[n, n]</strong>, <strong>text</strong>, <strong>blob</strong>, <strong>datetime</strong>, <strong>date</strong>, <strong>timestamp</strong> and <strong>time</strong>.</p>
 
-				<p class="note">If you are using Windows Powershell to execute oil commands, you need to enclose parameters with a comma in quotes (<strong>decimal['n, n']</strong>) so Powershell doesn't see them as arrays. Alternatively, you can use <a href="https://git-scm.com/downloads">Git Bash<a/>, especially if you are a git user too.</p> 
+				<p class="note">If you are using Windows Powershell to execute oil commands, you need to enclose parameters with a comma in quotes (<strong>decimal['n, n']</strong>) so Powershell doesn't see them as arrays. Alternatively, you can use <a href="https://git-scm.com/downloads">Git Bash</a>, especially if you are a git user too.</p>
 
 				<h3 id="migrations">Generating Migrations</h3>
 


### PR DESCRIPTION
Hello,

I've fixed a typo of a HTML tag at Oil -> Generate -> Running Migration section.

NB: This is my first time contributing at FuelPHP and I'm still learning about collaborating on GitHub. So, pardon me if I did something wrong and please tell me how should I do it.